### PR TITLE
Fixing source path on podspec

### DIFF
--- a/CMNavBarNotificationView.podspec
+++ b/CMNavBarNotificationView.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/edgurgel/CMNavBarNotificationView"
   s.license      = 'MIT'
   s.authors      = { "Eduardo Pinho" => "eduardo.gurgel@codeminer42.com", "Codeminer42" => "contato@codeminer42.com" }
-  s.source       = { :git => "https://github.com/lucasmedeirosleite/CMNavBarNotificationView.git", :tag => "1.0.3" }
+  s.source       = { :git => "https://github.com/edgurgel/CMNavBarNotificationView.git", :tag => "1.0.3" }
   s.platform     = :ios, '4.0'
   s.source_files = 'CMNavBarNotificationView/*.{h,m}','OBGradientView/*.{h,m}'
   s.public_header_files = 'CMNavBarNotificationView/**/*.h'


### PR DESCRIPTION
I removed the ./ on the files path (inside the podspec), the new version of cocoapods gem was unable to find the source, so when I ran pod install the CMNavBarNotificationView was empty, I removed ./ and it worked! And already added the version 1.0.2 on the podspec so you just create the tags and run pod spec lint :)
